### PR TITLE
Add support for in-context query keyword extraction: use summaries to contextualize extraction of keywords

### DIFF
--- a/README_graphloom.md
+++ b/README_graphloom.md
@@ -33,9 +33,26 @@ CUDA_VISIBLE_DEVICES=3 vllm serve intfloat/e5-mistral-7b-instruct --port 8003 --
     - Should local search also return themes? i.e., getting themes from entities by the-ent edges.
 - Global Search:
     - Somehow *_get_global_data* always gathers 0 relations, need to debug..
-- In-context Query Keyword Exaction:
+- (Done) In-context Query Keyword Exaction:
     - Instead of extracting keywords solely based on the query, we can also provide a summary of the RAG to the LLM for more accurate extraction.
     - For example, the global keywords extracted from the query "What are the top themes in this story?" are "Themes", "Story analysis", and "Literary elements", which naturally results in a poor match to the actual content/information in the RAG.
     - There are several ways to generate/maintain the summary of RAG. For example, in the kg_extraction prompt, we can also ask llm to briefly summarize the current chunk, and gradually adding the chunk summary to augment the summary of RAG and save it. Then during the query time, we can simply use this summary of RAG for query keyword extraction, and update it whenever the RAG gets new documents inserted.
 - Adaptive RAG:
     - will update..
+
+In-context Query Keyword Extraction:
+Enable with 
+```
+graphloom=True,
+graphloom_summary=True,
+```
+
+Example extraction for A Christmas Carol
+```
+(Pdb) hl_keywords
+['Themes', 'A Christmas Carol', 'Redemption', 'Family', 'Social responsibility', 'Spirit of Christmas']
+(Pdb) ll_keywords
+['Ebenezer Scrooge', 'Fred', 'Bob Cratchit', 'Jacob Marley', 'Christmas Past', 'Christmas Present', 'Christmas Yet to Come', 'Tiny Tim', 'Materialism', 'Empathy', 'Personal change']
+(Pdb) text
+'What are the top themes in this story?'
+```

--- a/dev_scripts/query_dickens_book.py
+++ b/dev_scripts/query_dickens_book.py
@@ -58,6 +58,7 @@ rag = LightRAG(
         func=embedding_func,
     ), #openai_embed,
     graphloom=True,
+    graphloom_summary=True,
     graph_storage="NetworkXHeteroStorage",
     log_level = 10, # DEBUG
     log_file_path = "/mnt/ssd1/mingyu/LightRAG/dev_scripts/graphloom.log"

--- a/lightrag/base.py
+++ b/lightrag/base.py
@@ -142,6 +142,10 @@ class BaseKVStorage(StorageNameSpace, ABC):
     @abstractmethod
     async def upsert(self, data: dict[str, dict[str, Any]]) -> None:
         """Upsert data"""
+        
+    async def get_all(self) -> dict[str, Any]:
+        """Get all data"""
+        pass    # optional to implement
 
 
 @dataclass

--- a/lightrag/kg/json_kv_impl.py
+++ b/lightrag/kg/json_kv_impl.py
@@ -38,6 +38,9 @@ class JsonKVStorage(BaseKVStorage):
             )
             for id in ids
         ]
+        
+    async def get_all(self) -> dict[str, Any]:
+        return self._data
 
     async def filter_keys(self, keys: set[str]) -> set[str]:
         return set(keys) - set(self._data.keys())

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -393,6 +393,12 @@ class LightRAG:
                 embedding_func=self.embedding_func,
                 meta_fields={"parent_name", "child_name"},
             )
+            self.summaries_kvs: BaseKVStorage = self.key_string_value_json_storage_cls(  # type: ignore
+                namespace=make_namespace(
+                    self.namespace_prefix, NameSpace.KV_STORE_SUMMARIES
+                ),
+                embedding_func=self.embedding_func,
+            )
             
         self.chunks_vdb: BaseVectorStorage = self.vector_db_storage_cls(  # type: ignore
             namespace=make_namespace(
@@ -815,6 +821,7 @@ class LightRAG:
                     relationships_vdb=self.relationships_vdb,
                     theme_vdb=self.themes_vdb,
                     theme_hierarchy_vdb=self.theme_hierarchies_vdb,
+                    summaries_kvs=self.summaries_kvs,
                     llm_response_cache=self.llm_response_cache,
                     global_config=asdict(self),
                 )

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -267,6 +267,9 @@ class LightRAG:
     
     graphloom: bool = field(default=False)
     """Controls whether to enable GraphLoom features for theme and theme hierarchy extraction."""
+    
+    graphloom_summary: bool = field(default=False)
+    """Controls whether to enable GraphLoom summary features for keyword extraction."""
 
     def __post_init__(self):
         os.makedirs(os.path.dirname(self.log_file_path), exist_ok=True)
@@ -1062,6 +1065,7 @@ class LightRAG:
                     self.relationships_vdb,
                     self.themes_vdb,
                     self.theme_hierarchies_vdb,
+                    self.summaries_kvs,
                     self.text_chunks,
                     param,
                     asdict(self),

--- a/lightrag/lightrag.py
+++ b/lightrag/lightrag.py
@@ -466,6 +466,7 @@ class LightRAG:
             # Add theme storages if graphloom is enabled
             if self.graphloom:
                 storages.extend([self.themes_vdb, self.theme_hierarchies_vdb])
+                storages.extend([self.summaries_kvs])
 
             for storage in storages:
                 if storage:
@@ -494,6 +495,7 @@ class LightRAG:
             # Add theme storages if graphloom is enabled
             if self.graphloom:
                 storages.extend([self.themes_vdb, self.theme_hierarchies_vdb])
+                storages.extend([self.summaries_kvs])
 
             for storage in storages:
                 if storage:
@@ -855,6 +857,7 @@ class LightRAG:
         if self.graphloom:
             tasks.append(self.themes_vdb.index_done_callback())
             tasks.append(self.theme_hierarchies_vdb.index_done_callback())
+            tasks.append(self.summaries_kvs.index_done_callback())
 
         await asyncio.gather(*tasks)
         logger.info("All Insert done")

--- a/lightrag/namespace.py
+++ b/lightrag/namespace.py
@@ -15,6 +15,7 @@ class NameSpace:
     # graphloom
     VECTOR_STORE_THEMES = "themes"
     VECTOR_STORE_THEME_HIERARCHIES = "theme_hierarchies"
+    KV_STORE_SUMMARIES = "summaries"
 
     GRAPH_STORE_CHUNK_ENTITY_RELATION = "chunk_entity_relation"
 

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1013,6 +1013,24 @@ async def extract_gl_kg(
             for source_id, summary in maybe_summaries.items()
         }
         await summaries_kvs.upsert(data_for_vdb)
+    
+        ### also upsert the combined summary to the kv store. Call LLM to generate a summary for the whole document
+        combined_summary = "\n".join(
+            [summary for summary in maybe_summaries.values()]
+        )
+        combined_summary_prompt = PROMPTS["COMBINED_SUMMARY_GENERATION"].format(
+            data=combined_summary
+        )
+        combined_summary = await use_llm_func(combined_summary_prompt, max_tokens=2000)
+        await summaries_kvs.upsert(
+            {
+                compute_mdhash_id("combined-summary", prefix="sum-"): {
+                    "source_id": "combined-summary",
+                    "summary": combined_summary,
+                }
+            }
+        )
+        breakpoint()
         
 async def extract_entities(
     chunks: dict[str, TextChunkSchema],

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -891,8 +891,8 @@ async def extract_gl_kg(
     maybe_nodes = defaultdict(list)
     maybe_edges = defaultdict(list)
     maybe_themes = defaultdict(list)
-    maybe_theme_hierarchies = defaultdict(str)
-    maybe_summaries = dict(str)
+    maybe_theme_hierarchies = defaultdict(list)
+    maybe_summaries = defaultdict(str)
     for m_nodes, m_edges, m_themes, m_theme_hierarchies, summary in results:
         for k, v in m_nodes.items():
             maybe_nodes[k].extend(v)
@@ -955,7 +955,7 @@ async def extract_gl_kg(
     #     f"New data extracted: entities:{all_entities_data}, relationships:{all_relationships_data}, "
     #     f"themes:{all_themes_data}, theme_hierarchies:{all_theme_hierarchies_data}"
     # )
-
+    
     if entity_vdb is not None:
         data_for_vdb = {
             compute_mdhash_id(dp["entity_name"], prefix="ent-"): {
@@ -1003,7 +1003,7 @@ async def extract_gl_kg(
             for dp in all_theme_hierarchies_data
         }
         await theme_hierarchy_vdb.upsert(data_for_vdb)
-        
+            
     if summaries_kvs is not None:
         data_for_vdb = {
             compute_mdhash_id(source_id, prefix="sum-"): {
@@ -1013,7 +1013,7 @@ async def extract_gl_kg(
             for source_id, summary in maybe_summaries.items()
         }
         await summaries_kvs.upsert(data_for_vdb)
-
+        
 async def extract_entities(
     chunks: dict[str, TextChunkSchema],
     knowledge_graph_inst: BaseGraphStorage,

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -1024,13 +1024,9 @@ async def extract_gl_kg(
         combined_summary = await use_llm_func(combined_summary_prompt, max_tokens=2000)
         await summaries_kvs.upsert(
             {
-                compute_mdhash_id("combined-summary", prefix="sum-"): {
-                    "source_id": "combined-summary",
-                    "summary": combined_summary,
-                }
+                "combined-summary": combined_summary
             }
         )
-        breakpoint()
         
 async def extract_entities(
     chunks: dict[str, TextChunkSchema],
@@ -1280,6 +1276,7 @@ async def gl_kg_query(
     relationships_vdb: BaseVectorStorage,
     themes_vdb: BaseVectorStorage,
     theme_hierarchies_vdb: BaseVectorStorage,
+    summaries_kvs: BaseKVStorage,
     text_chunks_db: BaseKVStorage,
     query_param: QueryParam,
     global_config: dict[str, str],
@@ -1294,10 +1291,12 @@ async def gl_kg_query(
     )
     if cached_response is not None:
         return cached_response
+    
+    combined_summary = await summaries_kvs.get_by_id("combined-summary")
 
     # Extract keywords using extract_keywords_only function which already supports conversation history
     hl_keywords, ll_keywords = await extract_keywords_only(
-        query, query_param, global_config, hashing_kv
+        query, query_param, global_config, hashing_kv, combined_summary
     )
 
     logger.debug(f"High-level keywords: {hl_keywords}")
@@ -1332,6 +1331,7 @@ async def gl_kg_query(
         relationships_vdb,
         themes_vdb,
         theme_hierarchies_vdb,
+        summaries_kvs,
         text_chunks_db,
         query_param,
     )
@@ -1515,6 +1515,7 @@ async def extract_keywords_only(
     param: QueryParam,
     global_config: dict[str, str],
     hashing_kv: BaseKVStorage | None = None,
+    combined_summary: str | None = None,
 ) -> tuple[list[str], list[str]]:
     """
     Extract high-level and low-level keywords from the given 'text' using the LLM.
@@ -1558,10 +1559,20 @@ async def extract_keywords_only(
         )
 
     # 4. Build the keyword-extraction prompt
-    kw_prompt = PROMPTS["keywords_extraction"].format(
-        query=text, examples=examples, language=language, history=history_context
-    )
-
+    kw_prompt = None
+    if global_config["graphloom_summary"] and combined_summary:
+        kw_prompt = PROMPTS["keywords_extraction_with_summary"].format(
+            query=text,
+            examples=examples,
+            language=language,
+            history=history_context,
+            summary=combined_summary    # TODO: can enhance to use the per-chunk summaries
+        )
+    else:
+        kw_prompt = PROMPTS["keywords_extraction"].format(
+            query=text, examples=examples, language=language, history=history_context
+        )
+        
     len_of_prompts = len(encode_string_by_tiktoken(kw_prompt))
     logger.debug(f"[kg_query]Prompt Tokens: {len_of_prompts}")
 
@@ -1582,7 +1593,7 @@ async def extract_keywords_only(
 
     hl_keywords = keywords_data.get("high_level_keywords", [])
     ll_keywords = keywords_data.get("low_level_keywords", [])
-
+    
     # 7. Cache only the processed keywords with cache type
     if hl_keywords or ll_keywords:
         cache_data = {
@@ -1817,6 +1828,7 @@ async def _build_gl_query_context(
     relationships_vdb: BaseVectorStorage,
     themes_vdb: BaseVectorStorage,
     theme_hierarchies_vdb: BaseVectorStorage,
+    summaries_kvs: BaseKVStorage,
     text_chunks_db: BaseKVStorage,
     query_param: QueryParam,
 ):

--- a/lightrag/operate.py
+++ b/lightrag/operate.py
@@ -685,9 +685,10 @@ async def extract_gl_kg(
     relationships_vdb: BaseVectorStorage,
     theme_vdb: BaseVectorStorage,
     theme_hierarchy_vdb: BaseVectorStorage,
+    summaries_kvs: BaseKVStorage,
     global_config: dict[str, str],
     llm_response_cache: BaseKVStorage | None = None,
-) -> None:
+) -> None:   
     use_llm_func: callable = global_config["llm_model_func"]
     entity_extract_max_gleaning = global_config["entity_extract_max_gleaning"]
     enable_llm_cache_for_entity_extract: bool = global_config[
@@ -890,7 +891,8 @@ async def extract_gl_kg(
     maybe_nodes = defaultdict(list)
     maybe_edges = defaultdict(list)
     maybe_themes = defaultdict(list)
-    maybe_theme_hierarchies = defaultdict(list)
+    maybe_theme_hierarchies = defaultdict(str)
+    maybe_summaries = dict(str)
     for m_nodes, m_edges, m_themes, m_theme_hierarchies, summary in results:
         for k, v in m_nodes.items():
             maybe_nodes[k].extend(v)
@@ -900,6 +902,8 @@ async def extract_gl_kg(
             maybe_themes[k].extend(v)
         for k, v in m_theme_hierarchies.items():
             maybe_theme_hierarchies[tuple(sorted(k))].extend(v)
+        if "summary" in summary and "source_id" in summary:
+            maybe_summaries[summary["source_id"]] = summary["summary"]
 
     all_entities_data = await asyncio.gather(
         *[
@@ -928,7 +932,7 @@ async def extract_gl_kg(
             for k, v in maybe_theme_hierarchies.items()
         ]
     )
-    
+        
     if not (all_entities_data or all_relationships_data or all_themes_data or all_theme_hierarchies_data):
         logger.info("Didn't extract any data (entities, relationships, themes, or theme hierarchies).")
         return
@@ -999,6 +1003,16 @@ async def extract_gl_kg(
             for dp in all_theme_hierarchies_data
         }
         await theme_hierarchy_vdb.upsert(data_for_vdb)
+        
+    if summaries_kvs is not None:
+        data_for_vdb = {
+            compute_mdhash_id(source_id, prefix="sum-"): {
+                "source_id": source_id,
+                "summary": summary,
+            }
+            for source_id, summary in maybe_summaries.items()
+        }
+        await summaries_kvs.upsert(data_for_vdb)
 
 async def extract_entities(
     chunks: dict[str, TextChunkSchema],

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -385,6 +385,43 @@ Output:
 
 """
 
+PROMPTS["keywords_extraction_with_summary"] = """---Role---
+
+You are a helpful assistant tasked with identifying both high-level and low-level keywords in the user's query and conversation history.
+
+---Goal---
+
+Given the query and conversation history, list both high-level and low-level keywords. High-level keywords focus on overarching concepts or themes, while low-level keywords focus on specific entities, details, or concrete terms.
+You are additionally given a summary of the knowledge store being queried by the user. Use this summary to help you contextualize and identify the keywords.
+---Instructions---
+
+- Consider both the current query and relevant conversation history when extracting keywords along with the summary of the knowledge store
+- Output the keywords in JSON format
+- The JSON should have two keys:
+  - "high_level_keywords" for overarching concepts or themes
+  - "low_level_keywords" for specific entities or details
+
+######################
+---Examples---
+######################
+{examples}
+
+#############################
+---Real Data---
+######################
+Conversation History:
+{history}
+
+Knowledge Store Summary:
+{summary}
+
+Current Query: {query}
+######################
+The `Output` should be human text, not unicode characters. Keep the same language as `Query`.
+Output:
+
+"""
+
 PROMPTS["keywords_extraction_examples"] = [
     """Example 1:
 

--- a/lightrag/prompt.py
+++ b/lightrag/prompt.py
@@ -12,6 +12,12 @@ PROMPTS["DEFAULT_COMPLETION_DELIMITER"] = "<|COMPLETE|>"
 
 PROMPTS["DEFAULT_ENTITY_TYPES"] = ["organization", "person", "geo", "event", "category"]
 
+PROMPTS["COMBINED_SUMMARY_GENERATION"] = """---Goal---
+Given a list of summaries, one for each chunk of the original input text, generate a comprehensive summary 
+of the data provided below:
+{data}
+"""
+
 ### Prompts for GraphLoom
 PROMPTS["kg_extraction"] = """---Goal---
 Given a text document, extract entities, relationships, and themes to build a two-view knowledge graph. The two-view knowledge graph has:


### PR DESCRIPTION
Index:
- Added per-chunk summary creation and combined summary generation to the indexing process by revising prompt to piggyback on existing extraction requests. 
- Add KV store for summaries

Query:
- Use summaries to extract keywords
- Added new prompt

Enable with flag: `graphloom_summary`

Updated readme w/ example: https://github.com/MingyuGuan/LightRAG/blob/kartik/graphloom/README_graphloom.md 